### PR TITLE
Apply prettierJS formating and better emoji insertion

### DIFF
--- a/src/freeMoji/index.tsx
+++ b/src/freeMoji/index.tsx
@@ -6,13 +6,16 @@ const logger = moonlight.getLogger("freeMoji");
 export const patches: ExtensionWebExports["patches"] = [
     {
         find: /canUseEmojisEverywhere:(\w+)/,
-        replace: [{
-            match: /canUseAnimatedEmojis:(\w+),/,
-            replacement: 'canUseAnimatedEmojis: () => true,'
-        }, {
-            match: /canUseEmojisEverywhere:(\w+),/,
-            replacement: 'canUseEmojisEverywhere: () => true,'
-        }]
+        replace: [
+            {
+                match: /canUseAnimatedEmojis:(\w+),/,
+                replacement: "canUseAnimatedEmojis: () => true,"
+            },
+            {
+                match: /canUseEmojisEverywhere:(\w+),/,
+                replacement: "canUseEmojisEverywhere: () => true,"
+            }
+        ]
     }
 ];
 
@@ -21,8 +24,8 @@ export const webpackModules: ExtensionWebExports["webpackModules"] = {
     entrypoint: {
         dependencies: [
             { ext: "common", id: "stores" },
-            { ext: 'spacepack', id: 'spacepack' },
+            { ext: "spacepack", id: "spacepack" }
         ],
         entrypoint: true
-    },
+    }
 };

--- a/src/freeMoji/manifest.json
+++ b/src/freeMoji/manifest.json
@@ -1,14 +1,14 @@
 {
-  "$schema": "https://moonlight-mod.github.io/manifest.schema.json",
-  "id": "freeMoji",
-  "version": "1.0.3",
-  "apiLevel": 2,
-  "meta": {
-    "name": "Freemoji",
-    "tagline": "Free Nitro emoji!",
-    "description": "Sends external emoji as image URLs instead. Based on the Vendetta extension by @maisymoe",
-    "authors": ["uwx", "maisymoe"],
-    "source": "https://github.com/uwx/moonlight-extensions"
-  },
-  "dependencies": ["spacepack"]
+    "$schema": "https://moonlight-mod.github.io/manifest.schema.json",
+    "id": "freeMoji",
+    "version": "1.0.3",
+    "apiLevel": 2,
+    "meta": {
+        "name": "Freemoji",
+        "tagline": "Free Nitro emoji!",
+        "description": "Sends external emoji as image URLs instead. Based on the Vendetta extension by @maisymoe",
+        "authors": ["uwx", "maisymoe"],
+        "source": "https://github.com/uwx/moonlight-extensions"
+    },
+    "dependencies": ["spacepack", "markdown"]
 }

--- a/src/freeMoji/manifest.json
+++ b/src/freeMoji/manifest.json
@@ -10,5 +10,5 @@
         "authors": ["uwx", "maisymoe"],
         "source": "https://github.com/uwx/moonlight-extensions"
     },
-    "dependencies": ["spacepack", "markdown"]
+    "dependencies": ["spacepack"]
 }

--- a/src/freeMoji/webpackModules/entrypoint.ts
+++ b/src/freeMoji/webpackModules/entrypoint.ts
@@ -2,7 +2,7 @@ import { EmojiStore, SelectedGuildStore } from "@moonlight-mod/wp/common_stores"
 import spacepack from "@moonlight-mod/wp/spacepack_spacepack";
 
 const logger = moonlight.getLogger("freeMoji/entrypoint");
-logger.info('Hello from freeMoji/entrypoint!');
+logger.info("Hello from freeMoji/entrypoint!");
 
 interface Message {
     content: string;
@@ -15,10 +15,9 @@ const module = spacepack.findByCode(COOL)[0].exports;
 
 const originalSend = module.Z.sendMessage;
 module.Z.sendMessage = async (...args: any[]) => {
-	modifyIfNeeded(args[1]);
-	return originalSend.call(module.Z, ...args);
+    modifyIfNeeded(args[1]);
+    return originalSend.call(module.Z, ...args);
 };
-
 
 // https://github.com/luimu64/nitro-spoof/blob/1bb75a2471c39669d590bfbabeb7b922672929f5/index.js#L25
 const hasEmotesRegex = /<a?:(\w+):(\d+)>/i;
@@ -58,8 +57,6 @@ export default function modifyIfNeeded(msg: Message) {
 
 	msg.content = newContent;
 
-	if (extractedEmojis.length > 0) msg.content += `\n${extractedEmojis.join("\n")}`;
-
-	// Set invalidEmojis to empty to prevent Discord yelling to you about you not having nitro
-	msg.invalidEmojis = [];
-};
+    // Set invalidEmojis to empty to prevent Discord yelling to you about you not having nitro
+    msg.invalidEmojis = [];
+}

--- a/src/freeMoji/webpackModules/entrypoint.ts
+++ b/src/freeMoji/webpackModules/entrypoint.ts
@@ -23,39 +23,34 @@ module.Z.sendMessage = async (...args: any[]) => {
 const hasEmotesRegex = /<a?:(\w+):(\d+)>/i;
 
 function extractUnusableEmojis(messageString: string, size: number) {
-	const emojiStrings = messageString.matchAll(/<a?:(\w+):(\d+)>/gi);
-	const emojiUrls = [];
+    const emojiStrings = messageString.matchAll(/<a?:(\w+):(\d+)>/gi);
 
-	for (const emojiString of emojiStrings) {
-		// Fetch required info about the emoji
-		const emoji = EmojiStore.getCustomEmojiById(emojiString[2]);
+    for (const emojiString of emojiStrings) {
+        // Fetch required info about the emoji
+        const emoji = EmojiStore.getCustomEmojiById(emojiString[2]);
 
-		// Check emoji usability
-		if (
-			emoji.guildId !== SelectedGuildStore.getGuildId() ||
-			emoji.animated
-		) {
-			// Remove emote from original msg
-			messageString = messageString.replace(emojiString[0], "");
-			// Add to emotes to send
-            
-			emojiUrls.push(`https://cdn.discordapp.com/emojis/${emoji.id}.webp?size=48${emoji.animated ? '&animated=true' : ''}`);
-		}
-	}
+        // Check emoji usability
+        if (emoji.guildId !== SelectedGuildStore.getGuildId() || emoji.animated) {
+            // Replace the discord emoji format with the corresponding emoji url
+            messageString = messageString.replace(
+                emojiString[0],
+                `[${emoji.allNamesString.replace(":", "")}](https://cdn.discordapp.com/emojis/${emoji.id}.webp?size=48${emoji.animated ? "&animated=true" : ""})`
+            );
+        }
+    }
 
-	return { 
-        newContent: messageString.trim(),
-        extractedEmojis: emojiUrls,
+    return {
+        newContent: messageString.trim()
     };
 }
 
 export default function modifyIfNeeded(msg: Message) {
-	if (!msg.content.match(hasEmotesRegex)) return;
+    if (!msg.content.match(hasEmotesRegex)) return;
 
-	// Find all emojis from the captured message string and return object with emojiURLS and content
-	const { newContent, extractedEmojis } = extractUnusableEmojis(msg.content, 48);
+    // Find all emojis from the captured message string and return object with emojiURLS and content
+    const { newContent } = extractUnusableEmojis(msg.content, 48);
 
-	msg.content = newContent;
+    msg.content = newContent;
 
     // Set invalidEmojis to empty to prevent Discord yelling to you about you not having nitro
     msg.invalidEmojis = [];

--- a/src/freeMoji/webpackModules/entrypoint.ts
+++ b/src/freeMoji/webpackModules/entrypoint.ts
@@ -34,7 +34,7 @@ function extractUnusableEmojis(messageString: string, size: number) {
             // Replace the discord emoji format with the corresponding emoji url
             messageString = messageString.replace(
                 emojiString[0],
-                `[${emoji.allNamesString.replace(":", "")}](https://cdn.discordapp.com/emojis/${emoji.id}.webp?size=48${emoji.animated ? "&animated=true" : ""})`
+                `[:${emoji.name}:](https://cdn.discordapp.com/emojis/${emoji.id}.webp?size=48${emoji.animated ? "&animated=true" : ""})`
             );
         }
     }


### PR DESCRIPTION
Emojis are now inserted just like how vencord's FakeNitro inserts them. Allowing for other extensions like my [emoji renderer](https://github.com/0x4c756e61/moonpool/tree/main/src/emojiRenderer) to easily parse the link and replace them with proper emojis while keeping vanilla users from seeing ugly and misplaced links